### PR TITLE
Add JDK 11 internal package to MinimalPackageSupplier

### DIFF
--- a/AdviseStaticEvictingClassloader/src/main/java/com/github/advisedtesting/classloader/MinimalPackageSupplier.java
+++ b/AdviseStaticEvictingClassloader/src/main/java/com/github/advisedtesting/classloader/MinimalPackageSupplier.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 import org.springframework.instrument.classloading.ShadowingClassLoader;
 
 /**
- * Spring's {@link ShadowingClassLoader} will still use it's defaults {@link ShadowingClassLoader#DEFAULT_EXCLUDED_PACKAGES}.
+ * Spring's {@link ShadowingClassLoader} will still use its defaults {@link ShadowingClassLoader#DEFAULT_EXCLUDED_PACKAGES}.
  * The packages will not be evicted from classloading by the {@link RunInClassLoaderInterceptor}.
  * The covered classes will be loaded by the parent (URLClassLoader) provided by the jvm to junit.
  * In any class loaded by junit itself, the class must be loaded from the parent classloader.
@@ -43,6 +43,7 @@ public class MinimalPackageSupplier implements Supplier<Stream<String>> {
       "com.github.advisedtesting.junit4",
       "com.github.advisedtesting.context",
       "com.github.advisedtesting.classloader",
+      "jdk",
       "org.springframework",
       "org.assertj",
       "org.junit",


### PR DESCRIPTION
To fix issues of the following nature:

```
Caused by: java.lang.IllegalAccessError: class jdk.internal.reflect.ConstructorAccessorImpl loaded by com.github.advisedtesting.classloader.EvictingClassLoader @6bee7e9a cannot access jdk/internal/reflect superclass jdk.internal.reflect.MagicAccessorImpl
at java.base/java.lang.ClassLoader.defineClass1(Native Method)
at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:877)
at com.github.advisedtesting.classloader.EvictingClassLoader.getClass(EvictingClassLoader.java:77)
at com.github.advisedtesting.classloader.EvictingClassLoader.loadClass(EvictingClassLoader.java:94)
```

Add the `jdk` package to `MinimalPackageSupplier`.