### PR TITLE
Create small dependabot conf

### DIFF
--- a/.github  /dependabot.yml
+++ b/.github  /dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
I like automatic updates. Dependabot is now better integrated in GitHub. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates.

This PR tries to add a lean config.

automatic merging could be done using some GitHub action. E.g., https://github.com/pascalgn/automerge-action. One could add

```yaml
    labels:
      - "dependencies"
```

and then auto merge PRs having that label.